### PR TITLE
hotfix: corregir visibilidad del texto de eventos al estar en modo oscuro

### DIFF
--- a/src/Vistas/Componentes/Moleculas/EventoInfo.jsx
+++ b/src/Vistas/Componentes/Moleculas/EventoInfo.jsx
@@ -24,19 +24,19 @@ const InfoEvento = ({ descripcion, puntos, periodoRenovacion, renovacion }) => {
           </Texto>
           <Texto gutterBottom sx={{ mb: 2 }}>
             <strong>Puntos:</strong>{' '}
-            <span style={{ color: colores.altertex[3], fontWeight: 500 }}>
+            <span style={{ color: colores.altertex[4], fontWeight: 500 }}>
               {puntos || 'No especificado'}
             </span>
           </Texto>
           <Texto gutterBottom sx={{ mb: 2 }}>
             <strong>Periodo de Renovación:</strong>{' '}
-            <span style={{ color: colores.altertex[3], fontWeight: 500 }}>
+            <span style={{ color: colores.altertex[4], fontWeight: 500 }}>
               {periodoRenovacion || 'No especificado'}
             </span>
           </Texto>
           <Texto gutterBottom sx={{ mb: 2 }}>
             <strong>Renovación:</strong>{' '}
-            <span style={{ color: colores.altertex[3], fontWeight: 500 }}>
+            <span style={{ color: colores.altertex[4], fontWeight: 500 }}>
               {renovacionEtiqueta || 'No especificado'}
             </span>
           </Texto>


### PR DESCRIPTION
## Plantilla PR FrontEnd

Última actualización 26/03/25

---

# Descripción

Corrección del color de texto en leer evento

## Tipo de cambio

- [x] Corrección de error (cambio no disruptivo que soluciona un problema)
- [ ] Nueva función (cambio no disruptivo que agrega funcionalidad)
- [ ] Cambio disruptivo (corrección o función que afecta la compatibilidad existente)
- [ ] Este cambio requiere una actualización en la documentación
- [ ] Camio mínimo (Visual o de bajo impacto, sin afectcar lógica )

---

# ¿Qué archivo fue el que modifiqué?

- EventoInfo.jsx

---

# ¿Cómo se ha probado?

Describe resumidamente cómo lo probaste y funciona. Ejemplo:

- Se probó manualmente en Chrome que el texto fuera legible tanto en modo oscuro como en modo claro.
---

### Cambios menores

- [x] Este PR realiza un cambio mínimo que no afecta la lógica del sistema
- [x] Se validó visualmente el componente afectado
- [x] No se realizaron pruebas unitarias porque no aplica
